### PR TITLE
[android] Don't group crash reports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import { Platform } from 'react-native';
 import StackTrace from 'stacktrace-js';
 import { Crashlytics } from 'react-native-fabric';
 
@@ -20,7 +21,18 @@ function init() {
     });
     // And then re-throw the exception with the original handler
     if (originalHandler) {
-      originalHandler(e, isFatal);
+      if (Platform.OS === 'ios') {
+        originalHandler(e, isFatal);
+      } else {
+        // On Android, throwing the original exception immediately results in the
+        // recordCustomExceptionName() not finishing before the app crashes and therefore not logged
+        // Add a delay to give it time to log the custom JS exception before crashing the app.
+        // The user facing effect of this delay is that separate JS errors will appear as separate
+        // issues in the Crashlytics dashboard.
+        setTimeout(() => {
+          originalHandler(e, isFatal);
+        }, 500);
+      }
     }
   }
   global.ErrorUtils.setGlobalHandler(errorHandler);


### PR DESCRIPTION
Fixes https://github.com/corymsmith/react-native-fabric/issues/77

The exceptions weren't being logged using `recordCustomExceptionName()` on Android because the crash from throwing the real exception happens before the `recordCustomExceptionName` can be logged.  Due to that the exceptions appeared grouped together in the React Native Android error handler.

Fix by putting in a short delay before re-throwing the exception to give time for the JS exception to be logged.

This doesn't happen on iOS becasue `recordCustomExceptionName` exists and is designed for this use case ([logging an exception right before crashing](https://docs.fabric.io/appledocs/Crashlytics/Classes/Crashlytics.html)).

On Android that method doesn't exist, so `react-native-fabric` uses `logException` which doesn't handle the case of being called right before crashing well.

Test Plan:
Verify that with this change, JS exceptions appears ungrouped in the Crashlytics dashboard for Android. 


